### PR TITLE
✨ feat: alba detail applicants list

### DIFF
--- a/app/(with-main-header)/alba/[formId]/_components/AlertSection.tsx
+++ b/app/(with-main-header)/alba/[formId]/_components/AlertSection.tsx
@@ -1,7 +1,7 @@
 import ApplicantsAlert from '@/app/(with-main-header)/alba/[formId]/_components/ApplicantsAlert';
-import { Recruitment } from '@/types/recruitment';
+import { Alba } from '@/types/alba';
 
-type SectionAlertProps = Pick<Recruitment, 'applyCount'>;
+type SectionAlertProps = Pick<Alba, 'applyCount'>;
 
 const AlertSection = ({ applyCount }: SectionAlertProps) => {
   return (

--- a/app/(with-main-header)/alba/[formId]/_components/Applications.tsx
+++ b/app/(with-main-header)/alba/[formId]/_components/Applications.tsx
@@ -82,28 +82,24 @@ const Applications = ({ formId }: ApplicationsProps) => {
             loadNextPage={fetchNextPage}
             loader={<p>Loading applications...</p>}
           >
-            {data?.pages.map((page, pageIndex) => (
-              <tr key={pageIndex}>
-                {page.data.map((application) => {
-                  return (
-                    <>
-                      <td className="py-6 border-b border-line-100">
-                        {application.name}
-                      </td>
-                      <td className="py-6 border-b border-line-100">
-                        {application.phoneNumber}
-                      </td>
-                      <td className="py-6 border-b border-line-100">
-                        {application.experienceMonths}
-                      </td>
-                      <td className="py-6 border-b border-line-100">
-                        {applicationStatus[application.status]}
-                      </td>
-                    </>
-                  );
-                })}
-              </tr>
-            ))}
+            {data?.pages.map((page) =>
+              page.data.map((application) => (
+                <tr key={application.applicantId}>
+                  <td className="py-6 border-b border-line-100">
+                    {application.name}
+                  </td>
+                  <td className="py-6 border-b border-line-100">
+                    {application.phoneNumber}
+                  </td>
+                  <td className="py-6 border-b border-line-100">
+                    {application.experienceMonths}
+                  </td>
+                  <td className="py-6 border-b border-line-100">
+                    {applicationStatus[application.status]}
+                  </td>
+                </tr>
+              )),
+            )}
           </InfiniteScroll>
         </tbody>
       </table>

--- a/app/(with-main-header)/alba/[formId]/_components/Applications.tsx
+++ b/app/(with-main-header)/alba/[formId]/_components/Applications.tsx
@@ -14,7 +14,7 @@ type ApplicationsProps = {
   formId: number;
 };
 
-const PAGE_LIMIT = 5;
+const PAGE_LIMIT = 2;
 
 const Applications = ({ formId }: ApplicationsProps) => {
   const [orderByExperience, toggleOrderByExperience] = useToggleOrderBy(
@@ -38,71 +38,62 @@ const Applications = ({ formId }: ApplicationsProps) => {
       <h3 className="text-black-500 font-2lg font-semibold lg:text-3xl">
         지원 현황
       </h3>
-      <table className="table-auto w-full text-left">
-        <thead className="text-black-100 font-regular text-md lg:text-xl">
-          <tr>
-            <th className="py-6 border-b border-line-100">이름</th>
-            <th className="py-6 border-b border-line-100">전화번호</th>
-            <th className="py-6 border-b border-line-100">
-              <button
-                onClick={toggleOrderByExperience}
-                className="flex gap-1 items-center lg:gap-2"
-              >
-                경력
-                <Image
-                  src={`/icons/arrow-${orderByExperience}.svg`}
-                  alt={orderByExperience}
-                  width={32}
-                  height={32}
-                  className="lg:w-9 lg:h-9"
-                />
-              </button>
-            </th>
-            <th className="py-6 border-b border-line-100">
-              <button
-                onClick={toggleOrderByStatus}
-                className="flex gap-1 items-center lg:gap-2"
-              >
-                상태
-                <Image
-                  src={`/icons/arrow-${orderByStatus}.svg`}
-                  alt={orderByExperience}
-                  width={32}
-                  height={32}
-                  className="lg:w-9 lg:h-9"
-                />
-              </button>
-            </th>
-          </tr>
-        </thead>
-        <tbody className="text-black-400 text-md font-regular lg:text-xl">
-          <InfiniteScroll
-            hasNextPage={hasNextPage}
-            isLoading={isFetchingNextPage}
-            loadNextPage={fetchNextPage}
-            loader={<p>Loading applications...</p>}
+      <div className="grid grid-cols-4 items-center gap-4 text-black-100 font-regular text-md lg:text-xl border-b border-line-100">
+        <div className="py-6">이름</div>
+        <div className="py-6">전화번호</div>
+        <div className="py-6">
+          <button
+            onClick={toggleOrderByExperience}
+            className="flex gap-1 items-center lg:gap-2"
           >
-            {data?.pages.map((page) =>
-              page.data.map((application) => (
-                <tr key={application.applicantId}>
-                  <td className="py-6 border-b border-line-100">
-                    {application.name}
-                  </td>
-                  <td className="py-6 border-b border-line-100">
-                    {application.phoneNumber}
-                  </td>
-                  <td className="py-6 border-b border-line-100">
-                    {application.experienceMonths}
-                  </td>
-                  <td className="py-6 border-b border-line-100">
-                    {applicationStatus[application.status]}
-                  </td>
-                </tr>
-              )),
-            )}
-          </InfiniteScroll>
-        </tbody>
-      </table>
+            경력
+            <Image
+              src={`/icons/arrow-${orderByExperience}.svg`}
+              alt={orderByExperience}
+              width={32}
+              height={32}
+              className="lg:w-9 lg:h-9"
+            />
+          </button>
+        </div>
+        <div className="py-6">
+          <button
+            onClick={toggleOrderByStatus}
+            className="flex gap-1 items-center lg:gap-2"
+          >
+            상태
+            <Image
+              src={`/icons/arrow-${orderByStatus}.svg`}
+              alt={orderByExperience}
+              width={32}
+              height={32}
+              className="lg:w-9 lg:h-9"
+            />
+          </button>
+        </div>
+      </div>
+      <div className="text-black-400 text-md font-regular lg:text-xl">
+        <InfiniteScroll
+          hasNextPage={hasNextPage}
+          isLoading={isFetchingNextPage}
+          loadNextPage={fetchNextPage}
+          loader={<p>Loading applications...</p>}
+        >
+          {data?.pages.map((page) =>
+            page.data.map((application) => (
+              <div
+                key={application.applicantId}
+                className="grid grid-cols-4 gap-4 border-b border-line-100 py-6"
+              >
+                <div>{application.name}</div>
+                <div>{application.phoneNumber}</div>
+                <div>{application.experienceMonths}</div>
+                <div>{applicationStatus[application.status]}</div>
+              </div>
+            )),
+          )}
+        </InfiniteScroll>
+      </div>
     </div>
   );
 };

--- a/app/(with-main-header)/alba/[formId]/_components/Applications.tsx
+++ b/app/(with-main-header)/alba/[formId]/_components/Applications.tsx
@@ -1,6 +1,9 @@
-import { keepPreviousData, useQuery } from '@tanstack/react-query';
-import { GetApplicationsResponse } from '@/types/application';
-import { useState } from 'react';
+'use client';
+
+import { GetApplicationsParameters, orderByType } from '@/types/application';
+import { Fragment, useState } from 'react';
+import useGetApplications from '@/app/(with-main-header)/alba/[formId]/_hooks/useGetApplications';
+import InfiniteScroll from '@/components/InfiniteScroll';
 
 type ApplicationsProps = {
   id: number;
@@ -9,10 +12,29 @@ type ApplicationsProps = {
 const PAGE_LIMIT = 5;
 
 const Applications = ({ id }: ApplicationsProps) => {
+  const searchParams: GetApplicationsParameters = {
+    limit: PAGE_LIMIT,
+    orderByExperience: 'asc',
+    orderByStatus: 'desc',
+  };
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useGetApplications({ formId: id, searchParams });
+
   return (
-    <section>
-      <h3>지원 현황</h3>
-    </section>
+    <InfiniteScroll
+      hasNextPage={hasNextPage}
+      isLoading={isFetchingNextPage}
+      onLoadMore={fetchNextPage}
+      loader={<p>Loading applications...</p>}
+    >
+      {data?.pages.map((page, pageIndex) => (
+        <Fragment key={pageIndex}>
+          {page.data.map((application) => (
+            <div key={application.id}>{application.name}</div>
+          ))}
+        </Fragment>
+      ))}
+    </InfiniteScroll>
   );
 };
 

--- a/app/(with-main-header)/alba/[formId]/_components/Applications.tsx
+++ b/app/(with-main-header)/alba/[formId]/_components/Applications.tsx
@@ -14,7 +14,7 @@ type ApplicationsProps = {
   formId: number;
 };
 
-const PAGE_LIMIT = 2;
+const PAGE_LIMIT = 5;
 
 const Applications = ({ formId }: ApplicationsProps) => {
   const [orderByExperience, toggleOrderByExperience] = useToggleOrderBy(

--- a/app/(with-main-header)/alba/[formId]/_components/Applications.tsx
+++ b/app/(with-main-header)/alba/[formId]/_components/Applications.tsx
@@ -1,0 +1,19 @@
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { GetApplicationsResponse } from '@/types/application';
+import { useState } from 'react';
+
+type ApplicationsProps = {
+  id: number;
+};
+
+const PAGE_LIMIT = 5;
+
+const Applications = ({ id }: ApplicationsProps) => {
+  return (
+    <section>
+      <h3>지원 현황</h3>
+    </section>
+  );
+};
+
+export default Applications;

--- a/app/(with-main-header)/alba/[formId]/_components/Applications.tsx
+++ b/app/(with-main-header)/alba/[formId]/_components/Applications.tsx
@@ -1,18 +1,22 @@
 'use client';
 
-import { GetApplicationsParameters, orderByTypes } from '@/types/application';
-import { Fragment } from 'react';
+import {
+  applicationStatus,
+  GetApplicationsParameters,
+  orderByTypes,
+} from '@/types/application';
 import useGetApplications from '@/app/(with-main-header)/alba/[formId]/_hooks/useGetApplications';
 import InfiniteScroll from '@/components/InfiniteScroll';
 import useToggleOrderBy from '@/app/(with-main-header)/alba/[formId]/_hooks/useToggleOrderBy';
+import Image from 'next/image';
 
 type ApplicationsProps = {
-  id: number;
+  formId: number;
 };
 
 const PAGE_LIMIT = 5;
 
-const Applications = ({ id }: ApplicationsProps) => {
+const Applications = ({ formId }: ApplicationsProps) => {
   const [orderByExperience, toggleOrderByExperience] = useToggleOrderBy(
     orderByTypes[1],
   );
@@ -27,29 +31,83 @@ const Applications = ({ id }: ApplicationsProps) => {
   };
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useGetApplications({ formId: id, searchParams });
+    useGetApplications({ formId, searchParams });
 
   return (
-    <>
-      <div>
-        <button onClick={toggleOrderByExperience}>Toggle Experience</button>
-        <button onClick={toggleOrderByStatus}>Toggle Status</button>
-      </div>
-      <InfiniteScroll
-        hasNextPage={hasNextPage}
-        isLoading={isFetchingNextPage}
-        loadNextPage={fetchNextPage}
-        loader={<p>Loading applications...</p>}
-      >
-        {data?.pages.map((page, pageIndex) => (
-          <Fragment key={pageIndex}>
-            {page.data.map((application) => (
-              <div key={application.id}>{application.name}</div>
+    <div>
+      <h3 className="text-black-500 font-2lg font-semibold lg:text-3xl">
+        지원 현황
+      </h3>
+      <table className="table-auto w-full text-left">
+        <thead className="text-black-100 font-regular text-md lg:text-xl">
+          <tr>
+            <th className="py-6 border-b border-line-100">이름</th>
+            <th className="py-6 border-b border-line-100">전화번호</th>
+            <th className="py-6 border-b border-line-100">
+              <button
+                onClick={toggleOrderByExperience}
+                className="flex gap-1 items-center lg:gap-2"
+              >
+                경력
+                <Image
+                  src={`/icons/arrow-${orderByExperience}.svg`}
+                  alt={orderByExperience}
+                  width={32}
+                  height={32}
+                  className="lg:w-9 lg:h-9"
+                />
+              </button>
+            </th>
+            <th className="py-6 border-b border-line-100">
+              <button
+                onClick={toggleOrderByStatus}
+                className="flex gap-1 items-center lg:gap-2"
+              >
+                상태
+                <Image
+                  src={`/icons/arrow-${orderByStatus}.svg`}
+                  alt={orderByExperience}
+                  width={32}
+                  height={32}
+                  className="lg:w-9 lg:h-9"
+                />
+              </button>
+            </th>
+          </tr>
+        </thead>
+        <tbody className="text-black-400 text-md font-regular lg:text-xl">
+          <InfiniteScroll
+            hasNextPage={hasNextPage}
+            isLoading={isFetchingNextPage}
+            loadNextPage={fetchNextPage}
+            loader={<p>Loading applications...</p>}
+          >
+            {data?.pages.map((page, pageIndex) => (
+              <tr key={pageIndex}>
+                {page.data.map((application) => {
+                  return (
+                    <>
+                      <td className="py-6 border-b border-line-100">
+                        {application.name}
+                      </td>
+                      <td className="py-6 border-b border-line-100">
+                        {application.phoneNumber}
+                      </td>
+                      <td className="py-6 border-b border-line-100">
+                        {application.experienceMonths}
+                      </td>
+                      <td className="py-6 border-b border-line-100">
+                        {applicationStatus[application.status]}
+                      </td>
+                    </>
+                  );
+                })}
+              </tr>
             ))}
-          </Fragment>
-        ))}
-      </InfiniteScroll>
-    </>
+          </InfiniteScroll>
+        </tbody>
+      </table>
+    </div>
   );
 };
 

--- a/app/(with-main-header)/alba/[formId]/_components/Applications.tsx
+++ b/app/(with-main-header)/alba/[formId]/_components/Applications.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { GetApplicationsParameters, orderByType } from '@/types/application';
-import { Fragment, useState } from 'react';
+import { GetApplicationsParameters, orderByTypes } from '@/types/application';
+import { Fragment } from 'react';
 import useGetApplications from '@/app/(with-main-header)/alba/[formId]/_hooks/useGetApplications';
 import InfiniteScroll from '@/components/InfiniteScroll';
+import useToggleOrderBy from '@/app/(with-main-header)/alba/[formId]/_hooks/useToggleOrderBy';
 
 type ApplicationsProps = {
   id: number;
@@ -12,29 +13,43 @@ type ApplicationsProps = {
 const PAGE_LIMIT = 5;
 
 const Applications = ({ id }: ApplicationsProps) => {
+  const [orderByExperience, toggleOrderByExperience] = useToggleOrderBy(
+    orderByTypes[1],
+  );
+  const [orderByStatus, toggleOrderByStatus] = useToggleOrderBy(
+    orderByTypes[1],
+  );
+
   const searchParams: GetApplicationsParameters = {
     limit: PAGE_LIMIT,
-    orderByExperience: 'asc',
-    orderByStatus: 'desc',
+    orderByExperience,
+    orderByStatus,
   };
+
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useGetApplications({ formId: id, searchParams });
 
   return (
-    <InfiniteScroll
-      hasNextPage={hasNextPage}
-      isLoading={isFetchingNextPage}
-      onLoadMore={fetchNextPage}
-      loader={<p>Loading applications...</p>}
-    >
-      {data?.pages.map((page, pageIndex) => (
-        <Fragment key={pageIndex}>
-          {page.data.map((application) => (
-            <div key={application.id}>{application.name}</div>
-          ))}
-        </Fragment>
-      ))}
-    </InfiniteScroll>
+    <>
+      <div>
+        <button onClick={toggleOrderByExperience}>Toggle Experience</button>
+        <button onClick={toggleOrderByStatus}>Toggle Status</button>
+      </div>
+      <InfiniteScroll
+        hasNextPage={hasNextPage}
+        isLoading={isFetchingNextPage}
+        loadNextPage={fetchNextPage}
+        loader={<p>Loading applications...</p>}
+      >
+        {data?.pages.map((page, pageIndex) => (
+          <Fragment key={pageIndex}>
+            {page.data.map((application) => (
+              <div key={application.id}>{application.name}</div>
+            ))}
+          </Fragment>
+        ))}
+      </InfiniteScroll>
+    </>
   );
 };
 

--- a/app/(with-main-header)/alba/[formId]/_components/Carousel.tsx
+++ b/app/(with-main-header)/alba/[formId]/_components/Carousel.tsx
@@ -4,9 +4,9 @@ import { useState, useEffect } from 'react';
 import Image from 'next/image';
 import IconEllipse480 from '@/public/icons/ellipse-480.svg';
 import IconEllipse481 from '@/public/icons/ellipse-481.svg';
-import { Recruitment } from '@/types/recruitment';
+import { Alba } from '@/types/alba';
 
-type CarouselProps = Pick<Recruitment, 'imageUrls'>;
+type CarouselProps = Pick<Alba, 'imageUrls'>;
 
 const Carousel = ({ imageUrls }: CarouselProps) => {
   const [currentSlide, setCurrentSlide] = useState(0);

--- a/app/(with-main-header)/alba/[formId]/_components/ContactSection.tsx
+++ b/app/(with-main-header)/alba/[formId]/_components/ContactSection.tsx
@@ -1,9 +1,9 @@
-import { Recruitment } from '@/types/recruitment';
+import { Alba } from '@/types/alba';
 import { calculateDDay } from '@/utils/dDayCalculator';
 import { formatDateWithSpace } from '@/utils/dateFormatter';
 
 type SectionContactProps = Pick<
-  Recruitment,
+  Alba,
   | 'recruitmentEndDate'
   | 'recruitmentStartDate'
   | 'storePhoneNumber'

--- a/app/(with-main-header)/alba/[formId]/_components/DescriptionSection.tsx
+++ b/app/(with-main-header)/alba/[formId]/_components/DescriptionSection.tsx
@@ -1,6 +1,6 @@
-import { Recruitment } from '@/types/recruitment';
+import { Alba } from '@/types/alba';
 
-type SectinoDescriptionProps = Pick<Recruitment, 'description'>;
+type SectinoDescriptionProps = Pick<Alba, 'description'>;
 
 const DescriptionSection = ({ description }: SectinoDescriptionProps) => {
   return (

--- a/app/(with-main-header)/alba/[formId]/_components/FixedActions.tsx
+++ b/app/(with-main-header)/alba/[formId]/_components/FixedActions.tsx
@@ -1,7 +1,7 @@
-import { Recruitment } from '@/types/recruitment';
+import { Alba } from '@/types/alba';
 import Image from 'next/image';
 
-type FixedActionsProps = Pick<Recruitment, 'isScrapped'>;
+type FixedActionsProps = Pick<Alba, 'isScrapped'>;
 
 const FixedActions = ({ isScrapped }: FixedActionsProps) => {
   return (

--- a/app/(with-main-header)/alba/[formId]/_components/FixedActions.tsx
+++ b/app/(with-main-header)/alba/[formId]/_components/FixedActions.tsx
@@ -1,21 +1,33 @@
+'use client';
+
 import { Alba } from '@/types/alba';
 import Image from 'next/image';
+import { postAlbaScrap } from '@/services/alba';
+import { useState } from 'react';
 
-type FixedActionsProps = Pick<Alba, 'isScrapped'>;
+type FixedActionsProps = Pick<Alba, 'id' | 'isScrapped'>;
 
-const FixedActions = ({ isScrapped }: FixedActionsProps) => {
+const FixedActions = ({ id, isScrapped }: FixedActionsProps) => {
+  const [isActiveScrapped, setIsActiveScrapped] = useState(isScrapped);
+
+  const handleScrapClick = async () => {
+    const result = await postAlbaScrap(id);
+    setIsActiveScrapped(result);
+    alert('스크랩성공!'); //TODO 토스트박스
+  };
+
   return (
     <aside className="fixed bottom-10 right-4 flex flex-col">
-      <button aria-label="스크랩하기">
+      <button type="button" onClick={handleScrapClick} aria-label="스크랩하기">
         <Image
-          src={`/icons/bookmark-circle-${isScrapped ? 'active' : 'inactive'}.svg`}
+          src={`/icons/bookmark-circle-${isActiveScrapped ? 'active' : 'inactive'}.svg`}
           alt={'스크랩'}
           width={54}
           height={54}
           className="lg:w-16 lg:h-16"
         />
       </button>
-      <button aria-label="공유하기">
+      <button type="button" aria-label="공유하기">
         <Image
           src={`/icons/share-circle.svg`}
           alt={'공유하기'}

--- a/app/(with-main-header)/alba/[formId]/_components/Location.tsx
+++ b/app/(with-main-header)/alba/[formId]/_components/Location.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { Recruitment } from '@/types/recruitment';
+import { Alba } from '@/types/alba';
 import GoogleMap from '@/app/(with-main-header)/alba/[formId]/_components/GoogleMap';
 
-type LocationProps = Pick<Recruitment, 'location'>;
+type LocationProps = Pick<Alba, 'location'>;
 
 const Location = ({ location }: LocationProps) => {
   const { address, coordinates } = JSON.parse(location);

--- a/app/(with-main-header)/alba/[formId]/_components/Requirements.tsx
+++ b/app/(with-main-header)/alba/[formId]/_components/Requirements.tsx
@@ -1,7 +1,7 @@
-import { Recruitment } from '@/types/recruitment';
+import { Alba } from '@/types/alba';
 
 type RequirementsProps = Pick<
-  Recruitment,
+  Alba,
   'numberOfPositions' | 'gender' | 'education' | 'age' | 'preferred'
 >;
 

--- a/app/(with-main-header)/alba/[formId]/_components/SummarySection.tsx
+++ b/app/(with-main-header)/alba/[formId]/_components/SummarySection.tsx
@@ -1,10 +1,10 @@
 import Badge from '@/components/Badge';
 import { formatFullDateTime } from '@/utils/dateFormatter';
 import Image from 'next/image';
-import { Recruitment } from '@/types/recruitment';
+import { Alba } from '@/types/alba';
 
 type SectionFirstProps = Pick<
-  Recruitment,
+  Alba,
   | 'isPublic'
   | 'createdAt'
   | 'storeName'

--- a/app/(with-main-header)/alba/[formId]/_components/TermsSection.tsx
+++ b/app/(with-main-header)/alba/[formId]/_components/TermsSection.tsx
@@ -1,9 +1,9 @@
 import TermsDetail from '@/app/(with-main-header)/alba/[formId]/_components/TermsDetail';
 import { formatDate } from '@/utils/dateFormatter';
-import { Recruitment } from '@/types/recruitment';
+import { Alba } from '@/types/alba';
 
 type SectionTermsProps = Pick<
-  Recruitment,
+  Alba,
   | 'hourlyWage'
   | 'workStartDate'
   | 'workEndDate'

--- a/app/(with-main-header)/alba/[formId]/_hooks/useGetApplications.tsx
+++ b/app/(with-main-header)/alba/[formId]/_hooks/useGetApplications.tsx
@@ -1,0 +1,28 @@
+import { GetApplicationsParameters } from '@/types/application';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { getApplications } from '@/services/application';
+
+type useGetApplicationsProps = {
+  formId: number;
+  searchParams: GetApplicationsParameters;
+};
+
+const useGetApplications = ({
+  formId,
+  searchParams,
+}: useGetApplicationsProps) => {
+  const queryFn = ({ pageParam = searchParams.cursor }) =>
+    getApplications({
+      formId,
+      params: { ...searchParams, cursor: pageParam },
+    });
+
+  return useInfiniteQuery({
+    queryKey: ['applications'],
+    queryFn,
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
+    initialPageParam: 0,
+  });
+};
+
+export default useGetApplications;

--- a/app/(with-main-header)/alba/[formId]/_hooks/useGetApplications.tsx
+++ b/app/(with-main-header)/alba/[formId]/_hooks/useGetApplications.tsx
@@ -22,7 +22,6 @@ const useGetApplications = ({
     queryFn,
     getNextPageParam: (lastPage) => lastPage.nextCursor,
     initialPageParam: 0,
-    retry: false, // TODO 에러 처리 후 제거
   });
 };
 

--- a/app/(with-main-header)/alba/[formId]/_hooks/useGetApplications.tsx
+++ b/app/(with-main-header)/alba/[formId]/_hooks/useGetApplications.tsx
@@ -18,10 +18,11 @@ const useGetApplications = ({
     });
 
   return useInfiniteQuery({
-    queryKey: ['applications'],
+    queryKey: ['applications', searchParams],
     queryFn,
     getNextPageParam: (lastPage) => lastPage.nextCursor,
     initialPageParam: 0,
+    retry: false,
   });
 };
 

--- a/app/(with-main-header)/alba/[formId]/_hooks/useGetApplications.tsx
+++ b/app/(with-main-header)/alba/[formId]/_hooks/useGetApplications.tsx
@@ -22,7 +22,7 @@ const useGetApplications = ({
     queryFn,
     getNextPageParam: (lastPage) => lastPage.nextCursor,
     initialPageParam: 0,
-    retry: false,
+    retry: false, // TODO 에러 처리 후 제거
   });
 };
 

--- a/app/(with-main-header)/alba/[formId]/_hooks/useToggleOrderBy.tsx
+++ b/app/(with-main-header)/alba/[formId]/_hooks/useToggleOrderBy.tsx
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+import { orderByType, orderByTypes } from '@/types/application';
+
+const useToggleOrderBy = (
+  initialValue: orderByType,
+): [orderByType, () => void] => {
+  const [value, setValue] = useState<orderByType>(initialValue);
+
+  const toggle = () => {
+    setValue((prev) =>
+      prev === orderByTypes[0] ? orderByTypes[1] : orderByTypes[0],
+    );
+  };
+
+  return [value, toggle];
+};
+
+export default useToggleOrderBy;

--- a/app/(with-main-header)/alba/[formId]/page.tsx
+++ b/app/(with-main-header)/alba/[formId]/page.tsx
@@ -8,6 +8,7 @@ import DescriptionSection from '@/app/(with-main-header)/alba/[formId]/_componen
 import FixedActions from '@/app/(with-main-header)/alba/[formId]/_components/FixedActions';
 import ApplicationActions from '@/app/(with-main-header)/alba/[formId]/_components/ApplicationActions';
 import Carousel from '@/app/(with-main-header)/alba/[formId]/_components/Carousel';
+import Applications from '@/app/(with-main-header)/alba/[formId]/_components/Applications';
 
 const mock = {
   isPublic: true,
@@ -53,38 +54,41 @@ const AlbaFormIdPage = async ({
   console.log(formId); // TODO api 호출 후 제거
 
   return (
-    <div>
-      <div className="-mx-6 md:-mx-[72px] flex justify-center">
-        <div className="w-full -mx-6">
-          <Carousel imageUrls={mock.imageUrls} />
-        </div>
-      </div>
+    <>
       <div>
-        <AlertSection applyCount={mock.applyCount} />
-        <div className="mt-8 md:mt-[80px]">
-          <SummarySection {...mock} />
+        <div className="-mx-6 md:-mx-[72px] flex justify-center">
+          <div className="w-full -mx-6">
+            <Carousel imageUrls={mock.imageUrls} />
+          </div>
         </div>
-        <div className="mt-8 md:mt-10">
-          <TermsSection {...mock} />
+        <div>
+          <AlertSection applyCount={mock.applyCount} />
+          <div className="mt-8 md:mt-[80px]">
+            <SummarySection {...mock} />
+          </div>
+          <div className="mt-8 md:mt-10">
+            <TermsSection {...mock} />
+          </div>
+          <div className="mt-8">
+            <ContactSection {...mock} />
+          </div>
+          <div className="mt-8">
+            <DescriptionSection description={mock.description} />
+          </div>
         </div>
         <div className="mt-8">
-          <ContactSection {...mock} />
+          <Requirements {...mock} />
         </div>
         <div className="mt-8">
-          <DescriptionSection description={mock.description} />
+          <Location location={mock.location} />
         </div>
+        <div className="mt-10 mb-[30px]">
+          <ApplicationActions formId={formId} />
+        </div>
+        <FixedActions isScrapped={mock.isScrapped} id={formId} />
       </div>
-      <div className="mt-8">
-        <Requirements {...mock} />
-      </div>
-      <div className="mt-8">
-        <Location location={mock.location} />
-      </div>
-      <div className="mt-10 mb-[30px]">
-        <ApplicationActions formId={formId} />
-      </div>
-      <FixedActions isScrapped={mock.isScrapped} id={formId} />
-    </div>
+      <Applications id={formId} />
+    </>
   );
 };
 

--- a/app/(with-main-header)/alba/[formId]/page.tsx
+++ b/app/(with-main-header)/alba/[formId]/page.tsx
@@ -87,7 +87,7 @@ const AlbaFormIdPage = async ({
         </div>
         <FixedActions isScrapped={mock.isScrapped} id={formId} />
       </div>
-      <Applications id={formId} />
+      <Applications formId={formId} />
     </>
   );
 };

--- a/app/(with-main-header)/alba/[formId]/page.tsx
+++ b/app/(with-main-header)/alba/[formId]/page.tsx
@@ -83,7 +83,7 @@ const AlbaFormIdPage = async ({
       <div className="mt-10 mb-[30px]">
         <ApplicationActions formId={formId} />
       </div>
-      <FixedActions isScrapped={mock.isScrapped} />
+      <FixedActions isScrapped={mock.isScrapped} id={formId} />
     </div>
   );
 };

--- a/components/InfiniteScroll.tsx
+++ b/components/InfiniteScroll.tsx
@@ -31,7 +31,7 @@ const InfiniteScroll = ({
   return (
     <>
       {children}
-      {isLoading ? loader : <div ref={ref} />}{' '}
+      {isLoading ? loader : <div ref={ref} />}
     </>
   );
 };

--- a/components/InfiniteScroll.tsx
+++ b/components/InfiniteScroll.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+type InfiniteScrollProps = {
+  loadMore: () => Promise<void>;
+  hasMore: boolean;
+  loader?: React.ReactNode;
+  children: React.ReactNode;
+};
+
+const InfiniteScroll = ({
+  loadMore,
+  hasMore,
+  loader,
+  children,
+}: InfiniteScrollProps) => {
+  return <div></div>;
+};
+
+export default InfiniteScroll;

--- a/components/InfiniteScroll.tsx
+++ b/components/InfiniteScroll.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import React, { ReactNode, useRef } from 'react';
+import React, { ReactNode, useCallback, useRef } from 'react';
 import useIntersectionObserver from '@/hooks/useIntersectionObserver';
 
 type InfiniteScrollProps = {
   children: ReactNode;
   hasNextPage: boolean;
   isLoading: boolean;
-  onLoadMore: () => void;
+  loadNextPage: () => void;
   loader?: ReactNode;
 };
 
@@ -15,25 +15,27 @@ const InfiniteScroll = ({
   children,
   hasNextPage,
   isLoading,
-  onLoadMore,
+  loadNextPage,
   loader,
 }: InfiniteScrollProps) => {
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
 
+  const handleIntersect = useCallback(() => {
+    if (hasNextPage && !isLoading) {
+      loadNextPage();
+    }
+  }, [hasNextPage, isLoading, loadNextPage]);
+
   useIntersectionObserver({
-    onIntersect: () => {
-      if (hasNextPage && !isLoading) {
-        onLoadMore();
-      }
-    },
+    onIntersect: handleIntersect,
     enabled: hasNextPage,
   })(loadMoreRef.current);
 
   return (
     <>
       {children}
-      {isLoading && loader}
       <div ref={loadMoreRef} />
+      {isLoading && loader}
     </>
   );
 };

--- a/components/InfiniteScroll.tsx
+++ b/components/InfiniteScroll.tsx
@@ -1,19 +1,41 @@
-import React from 'react';
+'use client';
+
+import React, { ReactNode, useRef } from 'react';
+import useIntersectionObserver from '@/hooks/useIntersectionObserver';
 
 type InfiniteScrollProps = {
-  loadMore: () => Promise<void>;
-  hasMore: boolean;
-  loader?: React.ReactNode;
-  children: React.ReactNode;
+  children: ReactNode;
+  hasNextPage: boolean;
+  isLoading: boolean;
+  onLoadMore: () => void;
+  loader?: ReactNode;
 };
 
 const InfiniteScroll = ({
-  loadMore,
-  hasMore,
-  loader,
   children,
+  hasNextPage,
+  isLoading,
+  onLoadMore,
+  loader,
 }: InfiniteScrollProps) => {
-  return <div></div>;
+  const loadMoreRef = useRef<HTMLDivElement | null>(null);
+
+  useIntersectionObserver({
+    onIntersect: () => {
+      if (hasNextPage && !isLoading) {
+        onLoadMore();
+      }
+    },
+    enabled: hasNextPage,
+  })(loadMoreRef.current);
+
+  return (
+    <>
+      {children}
+      {isLoading && loader}
+      <div ref={loadMoreRef} />
+    </>
+  );
 };
 
 export default InfiniteScroll;

--- a/components/InfiniteScroll.tsx
+++ b/components/InfiniteScroll.tsx
@@ -23,15 +23,15 @@ const InfiniteScroll = ({
   const { inView, ref } = useInView(inViewOptions);
 
   useEffect(() => {
-    if (inView && !isLoading && !hasNextPage) {
+    if (inView && hasNextPage && !isLoading) {
       loadNextPage();
     }
-  }, [inView, isLoading, hasNextPage, loadNextPage]);
+  }, [inView, hasNextPage, isLoading, loadNextPage]);
 
   return (
     <>
       {children}
-      {isLoading ? loader : <div ref={ref} />}
+      {isLoading ? loader : <div ref={ref} />}{' '}
     </>
   );
 };

--- a/components/InfiniteScroll.tsx
+++ b/components/InfiniteScroll.tsx
@@ -1,14 +1,15 @@
 'use client';
 
-import React, { ReactNode, useCallback, useRef } from 'react';
-import useIntersectionObserver from '@/hooks/useIntersectionObserver';
+import React, { ReactNode, useEffect } from 'react';
+import { IntersectionOptions, useInView } from 'react-intersection-observer';
 
-type InfiniteScrollProps = {
+type InfiniteScrollProps<T> = {
   children: ReactNode;
   hasNextPage: boolean;
   isLoading: boolean;
   loadNextPage: () => void;
   loader?: ReactNode;
+  inViewOptions?: T;
 };
 
 const InfiniteScroll = ({
@@ -17,25 +18,20 @@ const InfiniteScroll = ({
   isLoading,
   loadNextPage,
   loader,
-}: InfiniteScrollProps) => {
-  const loadMoreRef = useRef<HTMLDivElement | null>(null);
+  inViewOptions,
+}: InfiniteScrollProps<IntersectionOptions>) => {
+  const { inView, ref } = useInView(inViewOptions);
 
-  const handleIntersect = useCallback(() => {
-    if (hasNextPage && !isLoading) {
+  useEffect(() => {
+    if (inView && !isLoading && !hasNextPage) {
       loadNextPage();
     }
-  }, [hasNextPage, isLoading, loadNextPage]);
-
-  useIntersectionObserver({
-    onIntersect: handleIntersect,
-    enabled: hasNextPage,
-  })(loadMoreRef.current);
+  }, [inView, isLoading, hasNextPage, loadNextPage]);
 
   return (
     <>
       {children}
-      <div ref={loadMoreRef} />
-      {isLoading && loader}
+      {isLoading ? loader : <div ref={ref} />}
     </>
   );
 };

--- a/hooks/useIntersectionObserver.tsx
+++ b/hooks/useIntersectionObserver.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useEffect, useRef, useCallback } from 'react';
+
+type useIntersectionObserverProps = {
+  root?: Element | null;
+  rootMargin?: string;
+  threshold?: number | number[];
+  onIntersect: (entry: IntersectionObserverEntry) => void;
+  enabled?: boolean;
+};
+
+const useIntersectionObserver = ({
+  root = null,
+  rootMargin = '0px',
+  threshold = 0,
+  onIntersect,
+  enabled = true,
+}: useIntersectionObserverProps) => {
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  const observe = useCallback(
+    (node: Element | null) => {
+      if (!enabled || !node) return;
+
+      if (observerRef.current) observerRef.current.disconnect();
+
+      observerRef.current = new IntersectionObserver(
+        ([entry]) => {
+          if (entry.isIntersecting) {
+            onIntersect(entry);
+          }
+        },
+        { root, rootMargin, threshold },
+      );
+
+      observerRef.current.observe(node);
+    },
+    [enabled, root, rootMargin, threshold, onIntersect],
+  );
+
+  useEffect(() => {
+    return () => {
+      observerRef.current?.disconnect();
+    };
+  }, []);
+
+  return observe;
+};
+
+export default useIntersectionObserver;

--- a/hooks/useIntersectionObserver.tsx
+++ b/hooks/useIntersectionObserver.tsx
@@ -10,6 +10,9 @@ type useIntersectionObserverProps = {
   enabled?: boolean;
 };
 
+/**
+ * @deprecated useInView로 대체 추후 제거 예정
+ */
 const useIntersectionObserver = ({
   root = null,
   rootMargin = '0px',

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.54.2",
+        "react-intersection-observer": "^9.14.0",
         "zustand": "^5.0.2"
       },
       "devDependencies": {
@@ -6970,6 +6971,21 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.14.0.tgz",
+      "integrity": "sha512-AYqlmDZn85VUmlODwYym9y5OlqY2cFyIu41dkN0GJWvhdbd19Mh16mz5IH6fO1gp5V4FfQOO4m0zGc04Tj13rQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.54.2",
+    "react-intersection-observer": "^9.14.0",
     "zustand": "^5.0.2"
   },
   "devDependencies": {

--- a/public/icons/arrow-asc.svg
+++ b/public/icons/arrow-asc.svg
@@ -1,0 +1,5 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.5" y="0.5" width="39" height="39" rx="7.5" stroke="#E6E6E6"/>
+<path d="M14 27.0001V11M14 11L9 15.8695M14 11L19 15.8695" stroke="#F89A05" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M26 11.9999V28M26 28L21 23.1305M26 28L31 23.1305" stroke="#C4C4C4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icons/arrow-desc.svg
+++ b/public/icons/arrow-desc.svg
@@ -1,0 +1,5 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.5" y="0.5" width="39" height="39" rx="7.5" stroke="#E6E6E6"/>
+<path d="M14 27.0001V11M14 11L9 15.8695M14 11L19 15.8695" stroke="#C4C4C4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M26 11.9999V28M26 28L21 23.1305M26 28L31 23.1305" stroke="#F89A05" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icons/arrow-down.svg
+++ b/public/icons/arrow-down.svg
@@ -1,3 +1,0 @@
-<svg width="13" height="18" viewBox="0 0 13 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path id="Vector 614" d="M6.5 0.999867V17M6.5 17L1.5 12.1305M6.5 17L11.5 12.1305" stroke="#C4C4C4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/public/icons/arrow-down.svg
+++ b/public/icons/arrow-down.svg
@@ -1,0 +1,3 @@
+<svg width="13" height="18" viewBox="0 0 13 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path id="Vector 614" d="M6.5 0.999867V17M6.5 17L1.5 12.1305M6.5 17L11.5 12.1305" stroke="#C4C4C4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icons/arrow-up.svg
+++ b/public/icons/arrow-up.svg
@@ -1,3 +1,0 @@
-<svg width="13" height="18" viewBox="0 0 13 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path id="Vector 613" d="M6.5 17.0001V1M6.5 1L1.5 5.86947M6.5 1L11.5 5.86947" stroke="#C4C4C4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/public/icons/arrow-up.svg
+++ b/public/icons/arrow-up.svg
@@ -1,0 +1,3 @@
+<svg width="13" height="18" viewBox="0 0 13 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path id="Vector 613" d="M6.5 17.0001V1M6.5 1L1.5 5.86947M6.5 1L11.5 5.86947" stroke="#C4C4C4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/services/alba.ts
+++ b/services/alba.ts
@@ -2,7 +2,7 @@ import { instance } from './axiosInstance';
 import { Alba } from '@/types/alba';
 
 export const getAlbaDetail = async (formId: number) => {
-  const response = await instance.post<Alba>(`forms/${formId}`);
+  const response = await instance.get<Alba>(`forms/${formId}`);
 
   return response.data;
 };

--- a/services/alba.ts
+++ b/services/alba.ts
@@ -1,0 +1,14 @@
+import { instance } from './axiosInstance';
+import { Alba } from '@/types/alba';
+
+export const getAlbaDetail = async (formId: number) => {
+  const response = await instance.post<Alba>(`forms/${formId}`);
+
+  return response.data;
+};
+
+export const postAlbaScrap = async (formId: number) => {
+  const response = await instance.post<Alba>(`forms/${formId}/scrap`);
+
+  return response.data.isScrapped;
+};

--- a/services/application.ts
+++ b/services/application.ts
@@ -1,0 +1,22 @@
+import { instance } from '@/services/axiosInstance';
+import {
+  GetApplicationsParameters,
+  GetApplicationsResponse,
+} from '@/types/application';
+
+export const getApplications = async ({
+  formId,
+  params,
+}: {
+  formId: number;
+  params: GetApplicationsParameters;
+}) => {
+  const response = await instance.get<GetApplicationsResponse>(
+    `/forms/${formId}/applications`,
+    {
+      params,
+    },
+  );
+
+  return response.data;
+};

--- a/types/alba.ts
+++ b/types/alba.ts
@@ -1,4 +1,4 @@
-export interface Recruitment {
+export interface Alba {
   updatedAt: string;
   createdAt: string;
   preferred: string;

--- a/types/application.ts
+++ b/types/application.ts
@@ -1,0 +1,38 @@
+export const orderByTypes = ['asc', 'desc'];
+
+export const applicationStatus = {
+  REJECTED: '거절',
+  INTERVIEW_PENDING: '면접대기',
+  INTERVIEW_COMPLETED: '면접완료',
+  HIRED: '채용완료',
+} as const;
+
+export type ApplicationStatusType = keyof typeof applicationStatus;
+
+export type orderByType = (typeof orderByTypes)[number];
+
+export interface Application {
+  applicantId: number;
+  updatedAt: string;
+  createdAt: string;
+  status: ApplicationStatusType;
+  introduction: string;
+  resumeName: string;
+  resumeId: number;
+  experienceMonths: number;
+  phoneNumber: string;
+  name: string;
+  id: number;
+}
+
+export interface GetApplicationsResponse {
+  nextCursor: number;
+  data: Application[];
+}
+
+export interface GetApplicationsParameters {
+  cursor: number;
+  limit: number;
+  orderByExperience?: orderByType;
+  orderByStatus?: orderByType;
+}

--- a/types/application.ts
+++ b/types/application.ts
@@ -31,7 +31,7 @@ export interface GetApplicationsResponse {
 }
 
 export interface GetApplicationsParameters {
-  cursor: number;
+  cursor?: number;
   limit: number;
   orderByExperience?: orderByType;
   orderByStatus?: orderByType;


### PR DESCRIPTION
### 📌 Closed #26 

## 📝 Description

- 알바 상세조회 사장님 부분에서 맨밑에 지원현황 컴포넌트 구현
- 알바 상세 스크랩 api호출 추가

## 📷 Screenshot
<img width="354" alt="image" src="https://github.com/user-attachments/assets/a4563044-ff21-4e3a-8f07-472602dad542" />

## 📢 Notes

- 나름 시멘틱 하겠다고 지원현황 table태그로 첨에 만들었다가 table태그 자식요소 div안된다고 해가지고 바꿨어요... ㅋ_ㅋ 짜증나서 div 때려박은 느낌 없지않아 있습니다
- infiniteScroll 컴포넌트로 뺐는데 목록 페이지 구현 시 아마 가져다쓰면 동작 하지 않을까 싶습니다 ㅎㅎㅎ