### PR TITLE
🐛 fix: add convert to months on applications list

### DIFF
--- a/app/(with-main-header)/alba/[formId]/_components/Applications.tsx
+++ b/app/(with-main-header)/alba/[formId]/_components/Applications.tsx
@@ -11,6 +11,7 @@ import useToggleOrderBy from '@/app/(with-main-header)/alba/[formId]/_hooks/useT
 import Image from 'next/image';
 import Link from 'next/link';
 import ApplicationsSkeleton from '@/app/(with-main-header)/alba/[formId]/_components/skeleton/ApplicationsSkeleton';
+import { convertMonthsToYearsAndMonths } from '@/utils/dateFormatter';
 
 type ApplicationsProps = {
   formId: number;
@@ -110,7 +111,11 @@ const Applications = ({ formId }: ApplicationsProps) => {
                     </Link>
                   </div>
                   <div>{application.phoneNumber}</div>
-                  <div>{application.experienceMonths}</div>
+                  <div>
+                    {convertMonthsToYearsAndMonths(
+                      application.experienceMonths,
+                    )}
+                  </div>
                   <div>{applicationStatus[application.status]}</div>
                 </div>
               )),


### PR DESCRIPTION
## 📝 Description

- 알바 상세페이지 > 지원현황 > 경력 내용 처리 수정

## 📢 Notes

- 경력에 0년0개월 이렇게 나와야하는데 지금 그냥 숫자로만 나오고 있는 오류 수정했습니다

before:
<img width="177" alt="image" src="https://github.com/user-attachments/assets/6762c216-a52b-4039-b097-030ea58991cf" />
after:
<img width="138" alt="image" src="https://github.com/user-attachments/assets/09301ef7-8174-4396-8210-f9368ed6432c" />
